### PR TITLE
feat: Add setting activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
         android:theme="@style/Theme.Insubunhae"
         tools:targetApi="33">
         <activity
+            android:name=".SettingsActivity"
+            android:exported="false"
+            android:label="@string/title_activity_settings"
+            android:parentActivityName=".MainActivity"/>
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name">

--- a/app/src/main/java/com/sgcd/insubunhae/MainActivity.java
+++ b/app/src/main/java/com/sgcd/insubunhae/MainActivity.java
@@ -1,11 +1,13 @@
 package com.sgcd.insubunhae;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentTransaction;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
@@ -13,9 +15,11 @@ import androidx.navigation.ui.NavigationUI;
 import android.view.MenuInflater;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.view.MenuItem;
 
 import com.sgcd.insubunhae.databinding.ActivityMainBinding;
 import com.sgcd.insubunhae.db.DBHelper;
+import com.sgcd.insubunhae.ui.settings.SettingsFragment;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -51,11 +55,28 @@ public class MainActivity extends AppCompatActivity {
         NavigationUI.setupWithNavController(binding.navView, navController);
     }
 
+    // Inflating the menu items from the menu_items.xml file
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater=getMenuInflater();
         inflater.inflate(R.menu.menu, menu);
         return true;
     }
+    // Handling the click events of the menu items
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Switching on the item id of the menu item
+        switch (item.getItemId()) {
+            case R.id.menu_btn2:
+                Intent intent = new Intent(getApplicationContext(), SettingsActivity.class);
+                startActivity(intent);
+                break;
+            case R.id.menu_btn1:
+                break;
 
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+        return true;
+    }
 }

--- a/app/src/main/java/com/sgcd/insubunhae/SettingsActivity.java
+++ b/app/src/main/java/com/sgcd/insubunhae/SettingsActivity.java
@@ -1,0 +1,28 @@
+package com.sgcd.insubunhae;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.sgcd.insubunhae.ui.settings.SettingsFragment;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.settings_activity);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings, new SettingsFragment())
+                    .commit();
+        }
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+}

--- a/app/src/main/java/com/sgcd/insubunhae/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/sgcd/insubunhae/ui/settings/SettingsFragment.java
@@ -1,0 +1,15 @@
+package com.sgcd.insubunhae.ui.settings;
+
+import android.os.Bundle;
+
+import androidx.preference.PreferenceFragmentCompat;
+
+import com.sgcd.insubunhae.R;
+
+public class SettingsFragment extends PreferenceFragmentCompat {
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.setting_preferences, rootKey);
+    }
+}

--- a/app/src/main/java/com/sgcd/insubunhae/ui/settings/SettingsViewModel.java
+++ b/app/src/main/java/com/sgcd/insubunhae/ui/settings/SettingsViewModel.java
@@ -1,0 +1,19 @@
+package com.sgcd.insubunhae.ui.settings;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class SettingsViewModel extends ViewModel {
+
+    private final MutableLiveData<String> mText;
+
+    public SettingsViewModel() {
+        mText = new MutableLiveData<>();
+        mText.setValue("환경설정 화면");
+    }
+
+    public LiveData<String> getText() {
+        return mText;
+    }
+}

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -5,12 +5,7 @@
     <FrameLayout
         android:id="@+id/settings"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-
-        <Button android:text="back"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
+        android:layout_height="match_parent">
 
     </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -3,20 +3,19 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/menu_btn1"
-        android:title="버튼1"
-        app:showAsAction="always" />
+        android:title="@string/menu_button1"
+        app:showAsAction="ifRoom" />
     <item android:id="@+id/menu_btn2"
-        android:title="버튼2"
+        android:title="@string/menu_button2"
         app:showAsAction="always" />
     <item android:id="@+id/menu_btn3"
-        android:text="action_btn3"
-        android:title="버튼3"
+        android:title="@string/menu_button3"
         app:showAsAction="never" />
     <item android:id="@+id/menu_btn4"
-        android:title="버튼4"
+        android:title="@string/menu_button4"
         app:showAsAction="never"/>
     <item android:id="@+id/menu_btn5"
-        android:title="버튼5"
+        android:title="@string/menu_button5"
         app:showAsAction="never"/>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,5 +3,27 @@
     <string name="title_home">홈</string>
     <string name="title_statistics">통계</string>
     <string name="title_notifications">알림</string>
-    <string name="title_activity_settings">SettingsActivity</string>
+    <string name="title_activity_settings">설정</string>
+
+    <!-- Top menu buttons -->
+    <string name="menu_button1">버튼1</string>
+    <string name="menu_button2">설정</string>
+    <string name="menu_button3">버튼3</string>
+    <string name="menu_button4">버튼4</string>
+    <string name="menu_button5">버튼5</string>
+
+    <!-- Preference Titles -->
+    <string name="messages_header">Messages</string>
+    <string name="sync_header">Sync</string>
+
+    <!-- Messages Preferences -->
+    <string name="signature_title">Your signature</string>
+    <string name="reply_title">Default reply action</string>
+
+    <!-- Sync Preferences -->
+    <string name="sync_title">Sync email periodically</string>
+    <string name="attachment_title">Download incoming attachments</string>
+    <string name="attachment_summary_on">Automatically download attachments for incoming emails
+    </string>
+    <string name="attachment_summary_off">Only download attachments when manually requested</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,0 +1,65 @@
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory app:title="@string/messages_header">
+
+        <EditTextPreference
+            app:key="signature"
+            app:title="@string/signature_title"
+            app:useSimpleSummaryProvider="true" />
+
+        <ListPreference
+            app:defaultValue="reply"
+            app:entries="@array/reply_entries"
+            app:entryValues="@array/reply_values"
+            app:key="reply"
+            app:title="@string/reply_title"
+            app:useSimpleSummaryProvider="true" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/sync_header">
+
+        <SwitchPreferenceCompat
+            app:key="sync"
+            app:title="@string/sync_title" />
+
+        <SwitchPreferenceCompat
+            app:dependency="sync"
+            app:key="attachment"
+            app:summaryOff="@string/attachment_summary_off"
+            app:summaryOn="@string/attachment_summary_on"
+            app:title="@string/attachment_title" />
+
+    </PreferenceCategory>
+    <PreferenceCategory app:title="@string/messages_header">
+
+        <EditTextPreference
+            app:key="signature"
+            app:title="@string/signature_title"
+            app:useSimpleSummaryProvider="true" />
+
+        <ListPreference
+            app:defaultValue="reply"
+            app:entries="@array/reply_entries"
+            app:entryValues="@array/reply_values"
+            app:key="reply"
+            app:title="@string/reply_title"
+            app:useSimpleSummaryProvider="true" />
+
+    </PreferenceCategory>
+    <PreferenceCategory app:title="@string/sync_header">
+
+        <SwitchPreferenceCompat
+            app:key="sync"
+            app:title="@string/sync_title" />
+
+        <SwitchPreferenceCompat
+            app:dependency="sync"
+            app:key="attachment"
+            app:summaryOff="@string/attachment_summary_off"
+            app:summaryOn="@string/attachment_summary_on"
+            app:title="@string/attachment_title" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/setting_preferences.xml
+++ b/app/src/main/res/xml/setting_preferences.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory
-        android:title="일반">
+        android:title="일반"
+        >
         <PreferenceScreen
-            android:key="setting_password"
-            android:title="비밀번호 설정">
+            android:title="비밀번호 설정"
+            android:key="password_pref"
+            >
 
         </PreferenceScreen>
     </PreferenceCategory>


### PR DESCRIPTION
SettingsFragment.java, SettingsViewModel.java, SettingsActivity.java : added for setting menu. 
setting_preferences.xml : added for setting menu layout. 
root_preferences.xml : is a example code that is auto generated from Android Studio when creating SettingsActivity. (currently not using but yet leave)
string.xml : updated for menu button ids and new activity title.
AndroidManifest.xml : add parent info of SettingsActivity for back button operation.